### PR TITLE
Refactor PreviewMeasurements to show only print dimensions

### DIFF
--- a/src/components/PreviewMeasurements.jsx
+++ b/src/components/PreviewMeasurements.jsx
@@ -1,18 +1,25 @@
 import React from 'react'
 
-// Readout of the print/trim/viewable dimensions below the preview, plus the holder name.
-export const PreviewMeasurements = ({ selectedCardHolder, measurementSummary }) => (
-  <div className="preview-measurements">
-    {selectedCardHolder && (
-      <div className="preview-measurements__title">{selectedCardHolder.name}</div>
-    )}
-    <div className="preview-measurements__list">
-      {measurementSummary.map(({ label, value }) => (
-        <div key={label} className="preview-measurements__item">
-          <span>{label}</span>
-          <strong>{value}</strong>
-        </div>
-      ))}
+// Print-with-bleed readout below the preview. The holder name, insert and viewable
+// sizes already appear in the card-holder info box above, so they're omitted here to
+// avoid repeating the same information twice in the panel.
+export const PreviewMeasurements = ({ measurementSummary }) => {
+  const printItems = measurementSummary.filter(({ label }) => label === 'Print (with bleed)')
+
+  if (printItems.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="preview-measurements">
+      <div className="preview-measurements__list">
+        {printItems.map(({ label, value }) => (
+          <div key={label} className="preview-measurements__item">
+            <span>{label}</span>
+            <strong>{value}</strong>
+          </div>
+        ))}
+      </div>
     </div>
-  </div>
-)
+  )
+}

--- a/src/components/SignPreview.jsx
+++ b/src/components/SignPreview.jsx
@@ -133,10 +133,7 @@ export const SignPreview = ({ signData, cardHolders }) => {
           </div>
         )}
 
-        <PreviewMeasurements
-          selectedCardHolder={selectedCardHolder}
-          measurementSummary={measurementSummary}
-        />
+        <PreviewMeasurements measurementSummary={measurementSummary} />
       </div>
 
       <SignStyleControls


### PR DESCRIPTION
## Summary
Simplified the `PreviewMeasurements` component to display only the "Print (with bleed)" measurement, removing redundant information that already appears in the card-holder info box.

## Key Changes
- **PreviewMeasurements component**: 
  - Removed `selectedCardHolder` prop and the holder name display
  - Changed from functional component to standard function syntax
  - Added filtering logic to show only "Print (with bleed)" measurements
  - Returns `null` if no print measurements are available
  - Updated component comment to reflect new purpose and rationale

- **SignPreview component**:
  - Removed `selectedCardHolder` prop from `PreviewMeasurements` call
  - Simplified component usage to pass only `measurementSummary`

## Implementation Details
The component now filters the measurement summary array to extract only items with the label "Print (with bleed)" and renders them. This eliminates duplication since holder name, insert size, and viewable dimensions are already displayed in the card-holder info box above the preview.

https://claude.ai/code/session_01UVS5r1tWcVnTCKaYTMoZL8